### PR TITLE
fix(core): Remove reference to "Angular 2" in dev mode warning

### DIFF
--- a/modules/@angular/core/src/application_ref.ts
+++ b/modules/@angular/core/src/application_ref.ts
@@ -469,7 +469,7 @@ export class ApplicationRef_ extends ApplicationRef {
     this._loadComponent(compRef);
     if (isDevMode()) {
       this._console.log(
-          `Angular 2 is running in the development mode. Call enableProdMode() to enable the production mode.`);
+          `Angular is running in the development mode. Call enableProdMode() to enable the production mode.`);
     }
     return compRef;
   }


### PR DESCRIPTION
issue #13743